### PR TITLE
Revert "Merge pull request #27 from hankei6km/topic/readme"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Start [WebContainer](https://webcontainers.io/), and use Jsh and Preview URL.
 
 This extension dynamically generates an external tab with Cross Origin isolation enabled using [Nodebox](https://sandpack.codesandbox.io/docs/advanced-usage/nodebox)(the `Server` tab in the figure below). Therefore, the [`?vscode-coi=on`](https://github.com/microsoft/vscode/issues/137884) parameter is not required in VS Code for the Web.
 
-![Screenshot of Vite server running in Jsh terminal and previewing the page](https://raw.githubusercontent.com/hankei6km/vscode-ext-start-webcontainer/main/images/screenshot.png)
+![Screenshot of Vite server running in Jsh terminal and previewing the page](images/screenshot.png)
 
 > ⚠️ VS Code Insiders
 >


### PR DESCRIPTION
This reverts commit 7b7ba78813cf794c067c8fd26585807beea41cf2, reversing
changes made to a759d144cd5fe714e5c34df3a136d1a2bb50d29f.

https://insiders.vscode.dev/ で README
を確認したら画像が表示されされなかったのでリポジトリの画像ファイルへ明示的にリンクした。

よくよく確認すると、他の拡張機能でも表示されなかった。`vscode-coi` の影響のもよう。
何か対応入るだろうから、普通の方法に戻しておく。
