### PR TITLE
chore: Update vite in vitest with "npm audit fix"

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2782,9 +2782,9 @@
       }
     },
     "node_modules/vite-node/node_modules/vite": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-      "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
@@ -3320,9 +3320,9 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.5.tgz",
-      "integrity": "sha512-OekeWqR9Ls56f3zd4CaxzbbS11gqYkEiBtnWFFgYR2WV8oPJRRKq0mpskYy/XaoCL3L7VINDhqqOMNDiYdGvGg==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
@@ -5219,9 +5219,9 @@
           }
         },
         "vite": {
-          "version": "5.0.11",
-          "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-          "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+          "version": "5.0.12",
+          "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+          "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
           "dev": true,
           "requires": {
             "esbuild": "^0.19.3",
@@ -5467,9 +5467,9 @@
           }
         },
         "vite": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.5.tgz",
-          "integrity": "sha512-OekeWqR9Ls56f3zd4CaxzbbS11gqYkEiBtnWFFgYR2WV8oPJRRKq0mpskYy/XaoCL3L7VINDhqqOMNDiYdGvGg==",
+          "version": "5.0.12",
+          "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+          "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
           "dev": true,
           "requires": {
             "esbuild": "^0.19.3",


### PR DESCRIPTION
https://github.com/advisories/GHSA-c24v-8rfc-w8vw
